### PR TITLE
I faced an issue when i try to send an sms

### DIFF
--- a/src/TwilioComponent.php
+++ b/src/TwilioComponent.php
@@ -111,7 +111,7 @@ class TwilioComponent extends Component
      * @return string
      *
      */
-    protected function parseFrom(string $from): string
+    protected function parseFrom(string $from)
     {
         if (null === $from) {
             if (null === $this->phoneNumber) {


### PR DESCRIPTION
Exception 'TypeError' with message 'Argument 1 passed to dosamigos\twilio\TwilioComponent::parseFrom() must be of the type string, null given, called in E:\wamp64\www\GigsHero\vendor\2amigos\yii2-twilio-component\src\TwilioComponent.php on line 69'

I am getting the above error when I send an SMS. I found a solution and i would like to share it with you

Simply removing the string qualifier from vendor/2amigos/yii2-twilio-component/src/TwilioComponent.php:114 also fixes the issue.
